### PR TITLE
Add automatic access demo page

### DIFF
--- a/public/automatic-access-demo.html
+++ b/public/automatic-access-demo.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Automatic Access – Phone Preview</title>
+  <style>
+    :root {
+      --bg:#0b0f1a;
+      --phone:#0f1424;
+      --glass:#131a2caa;
+      --accent:#7c4dff;
+      --text:#e6ecff;
+      --muted:#9fb2ff;
+    }
+    * { box-sizing: border-box; }
+    html,body { height:100%; margin:0; }
+    body {
+      display:grid; place-items:center; background:radial-gradient(1200px 800px at 70% 10%, #1a2250 0%, #0b0f1a 60%) var(--bg);
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
+      color:var(--text);
+    }
+    .phone {
+      width:360px; height:740px; border-radius:44px; background:linear-gradient(180deg, #121a2b 0%, #0c1120 100%);
+      border:1px solid #2a355a; box-shadow:0 40px 120px #0008, inset 0 0 0 12px #0b10207a;
+      position:relative; overflow:hidden;
+    }
+    .notch {
+      position:absolute; top:10px; left:50%; transform:translateX(-50%);
+      width:160px; height:28px; border-radius:14px; background:#000c;
+    }
+    .screen {
+      position:absolute; inset:28px 12px 12px; border-radius:32px; background:
+        radial-gradient(600px 280px at 20% -10%, #1f2a66 0%, transparent 60%),
+        linear-gradient(180deg, #0d1330 0%, #0b0f1a 80%);
+      border:1px solid #232f56; padding:24px; display:flex; flex-direction:column; gap:20px;
+    }
+    .badge {
+      align-self:flex-start; display:inline-flex; align-items:center; gap:12px;
+      padding:12px 14px; border-radius:18px; background:linear-gradient(180deg, #182048aa, #0f173a88);
+      border:1px solid #2b3972; box-shadow:0 8px 30px #0006, inset 0 1px 0 #3a4aa5aa;
+      backdrop-filter: blur(6px);
+    }
+    .badge img { width:28px; height:28px; display:block; }
+    h1 {
+      margin:0; font-size:24px; letter-spacing:.2px;
+      background:linear-gradient(180deg, #ffffff, #bcd0ff 80%); -webkit-background-clip:text; background-clip:text; color:transparent;
+    }
+    p { margin:0; color:var(--muted); }
+    .card {
+      margin-top:auto; border-radius:22px; padding:18px; background:linear-gradient(180deg, #0f1737, #0c122c);
+      border:1px solid #263469; box-shadow:inset 0 1px 0 #3a4aa5aa;
+    }
+    .cta {
+      margin-top:14px; width:100%; padding:14px 16px; border-radius:14px; border:0; cursor:pointer;
+      background:linear-gradient(90deg, #6a5cff, #00d0ff); color:#061025; font-weight:600;
+      box-shadow:0 10px 30px #0035ff66, inset 0 1px 0 #ffffff55;
+    }
+    .footer {
+      position:absolute; bottom:14px; left:0; right:0; display:flex; justify-content:center; color:#7f95ff;
+      font-size:12px; opacity:.8;
+    }
+    @media (max-width:420px){ .phone{ transform:scale(.9); } }
+  </style>
+</head>
+<body>
+  <div class="phone">
+    <div class="notch"></div>
+    <div class="screen">
+      <div class="badge" title="Automatic access icon">
+        <img alt="Automatic access" src="data:image/webp;base64,UklGRiQbAABXRUJQVlA4WAoAAAAgAAAAgQAAAgAAQUxQSGkAAAABABMAnQEqADoAPwAPuKaI+QAAAP//2wBDAAQDAwQDAwQEBAQFBQUGBggHBwYICAkLCQoKCQwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAf/2wBDAQYHBwYICAkJCQkMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAf/wAARCAB4AIADASIAAhEBAxEB/8QAFwABAQEBAAAAAAAAAAAAAAAAAAQFCP/EABUBAQEAAAAAAAAAAAAAAAAAAAAC/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AL8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD8gAAAAAAAAAAAAAAAH8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD//Z" />
+        <strong>Automatic access</strong>
+      </div>
+
+      <div>
+        <h1>Enabled on this device</h1>
+        <p>No token needed. Shipped via PR with the image inlined.</p>
+      </div>
+
+      <div class="card">
+        <p>This demo page lives in the repo at <code>public/automatic-access-demo.html</code>.</p>
+        <button class="cta">Looks good</button>
+      </div>
+    </div>
+    <div class="footer">© Your App</div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add phone-themed Automatic Access demo page with inline base64 icon

## Testing
- `npm test` (fails: enoent package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c3e79bf2b4832b9243f429b2bc687a