### PR TITLE
Remove white badge overlay and add iPhone 3D thickness

### DIFF
--- a/assets/iphone-patch.js
+++ b/assets/iphone-patch.js
@@ -1,0 +1,34 @@
+/* Finds the largest tilted, rounded, absolutely-positioned element (the iPhone mockup)
+   and tags it so the CSS above can add a clean, right-side thickness edge.
+   Also removes the "Automatic access badge" card image by exact alt/src. */
+(function () {
+  try {
+    // Remove the white badge/card overlay image
+    document.querySelectorAll('img[alt="Automatic access badge"], img[src*="automatic-access"]')
+      .forEach(el => el.remove());
+
+    // Heuristic: biggest transformed, rounded, absolutely/fixed positioned element = the phone
+    const all = Array.from(document.querySelectorAll('body *'));
+    const candidates = all.filter(el => {
+      const cs = getComputedStyle(el);
+      const hasTransform = cs.transform && cs.transform !== 'none';
+      const hasRadius = ['borderTopLeftRadius','borderTopRightRadius','borderBottomLeftRadius','borderBottomRightRadius']
+        .some(k => (parseFloat(cs[k]) || 0) >= 16);
+      const rect = el.getBoundingClientRect();
+      const bigEnough = rect.width > 260 && rect.height > 500;
+      const absolutelyPlaced = cs.position === 'absolute' || cs.position === 'fixed';
+      return hasTransform && hasRadius && bigEnough && absolutelyPlaced;
+    });
+
+    const phone = candidates.sort((a, b) =>
+      (b.getBoundingClientRect().width * b.getBoundingClientRect().height) -
+      (a.getBoundingClientRect().width * a.getBoundingClientRect().height)
+    )[0];
+
+    if (phone && !phone.hasAttribute('data-iphone-mockup')) {
+      phone.setAttribute('data-iphone-mockup', '');
+    }
+  } catch (e) {
+    console.warn('iphone patch failed:', e);
+  }
+})();

--- a/assets/override.css
+++ b/assets/override.css
@@ -1,0 +1,27 @@
+/* 1) Remove the big white badge/card that sits on top of the phone */
+img[alt="Automatic access badge"],
+img[src*="automatic-access"] {
+  display: none !important;
+}
+
+/* 2) Visual thickness for the iPhone mockup (applied via data-attribute set by JS) */
+[data-iphone-mockup]{
+  position: relative !important;
+  /* strong, nice depth */
+  filter: drop-shadow(0 20px 30px rgba(0,0,0,.35))
+          drop-shadow(10px 0 0 rgba(255,255,255,.07));
+}
+
+/* right-side “edge” to make the device feel thicker */
+[data-iphone-mockup]::after{
+  content: "";
+  position: absolute;
+  right: -12px;
+  top: 5%;
+  bottom: 5%;
+  width: 18px;
+  border-radius: 0 28px 28px 0;
+  background: linear-gradient(180deg, rgba(255,255,255,.28), rgba(0,0,0,.50));
+  box-shadow: inset -2px 0 4px rgba(255,255,255,.25), inset 2px 0 4px rgba(0,0,0,.40);
+  pointer-events: none;
+}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>quali.chat — token-gated chat</title>
   <meta name="color-scheme" content="dark light">
+  <link rel="stylesheet" href="/assets/override.css">
   <style>
   :root{--bg:#05070C;--text:#fff;--muted:rgba(255,255,255,.75);--line:rgba(255,255,255,.12);--panel:rgba(255,255,255,.04);--panel2:rgba(255,255,255,.02);--shadow:0 40px 120px rgba(0,0,0,.6)}
   *{box-sizing:border-box}html,body{margin:0;height:100%;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Inter,Helvetica,Arial;background:#000;color:var(--text)}
@@ -368,5 +369,6 @@ body, p, li, a, button, input, textarea, small, label{
 })();
   </script>
   <script defer src="autoaccess.js"></script>
+  <script src="/assets/iphone-patch.js"></script>
   </body>
-  </html>
+</html>

--- a/public/automatic-access-demo.html
+++ b/public/automatic-access-demo.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Automatic Access – Phone Preview</title>
+  <link rel="stylesheet" href="/assets/override.css">
   <style>
     :root {
       --bg:#0b0f1a;
@@ -84,5 +85,6 @@
     </div>
     <div class="footer">© Your App</div>
   </div>
-</body>
-</html>
+  <script src="/assets/iphone-patch.js"></script>
+  </body>
+  </html>


### PR DESCRIPTION
## Summary
- Remove existing white badge overlay image and support thicker iPhone mockup
- Add CSS to hide badge and show 3D edge, JavaScript to tag phone element
- Include override CSS and JS across pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d09b0c10832b84a78419f65c418e