### PR TITLE
Align footer with quali.chat and add legal placeholders

### DIFF
--- a/acceptable-use-policy.html
+++ b/acceptable-use-policy.html
@@ -1,0 +1,15 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>Acceptable Use Policy – Quali.chat</title><link rel="stylesheet" href="/styles.css"/><style>body{min-height:100svh;display:flex;flex-direction:column}.wrap{max-width:880px;margin:0 auto;padding:2rem}.card{backdrop-filter:saturate(140%) blur(8px);background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.12);border-radius:16px;padding:1.25rem}h1{font-size:2rem;margin:1rem 0 1.25rem}footer{margin-top:auto}</style></head><body>
+<main class="wrap">
+  <h1>Acceptable Use Policy</h1>
+  <div class="card">
+    <p><strong>Content pending.</strong> To include the full AUP here, paste your owned/authorized text. For now, visit the original page:</p>
+    <p><a href="https://quali.chat/acceptable-use-policy/">https://quali.chat/acceptable-use-policy/</a></p>
+  </div>
+</main>
+<footer class="site-footer" style="margin-top:3rem;padding:2.5rem 1rem;border-top:1px solid rgba(255,255,255,.12);text-align:center">
+  <nav class="footer-links">
+    <a href="/">Home</a><a href="/support.html">Support</a><a href="/terms-of-use.html">Terms of Use</a><a href="/privacy-policy.html">Privacy Policy</a><a href="/acceptable-use-policy.html">Acceptable Use Policy</a><a href="/copyright.html">Copyright</a>
+  </nav>
+  <div style="opacity:.7;margin-top:.5rem">© 2024 quali.chat. All rights reserved.</div>
+</footer>
+</body></html>

--- a/copyright.html
+++ b/copyright.html
@@ -1,0 +1,15 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>Copyright – Quali.chat</title><link rel="stylesheet" href="/styles.css"/><style>body{min-height:100svh;display:flex;flex-direction:column}.wrap{max-width:880px;margin:0 auto;padding:2rem}.card{backdrop-filter:saturate(140%) blur(8px);background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.12);border-radius:16px;padding:1.25rem}h1{font-size:2rem;margin:1rem 0 1.25rem}footer{margin-top:auto}</style></head><body>
+<main class="wrap">
+  <h1>Copyright</h1>
+  <div class="card">
+    <p><strong>Content pending.</strong> To include the full Copyright policy here, paste your owned/authorized text. For now, visit the original page:</p>
+    <p><a href="https://quali.chat/copyright/">https://quali.chat/copyright/</a></p>
+  </div>
+</main>
+<footer class="site-footer" style="margin-top:3rem;padding:2.5rem 1rem;border-top:1px solid rgba(255,255,255,.12);text-align:center">
+  <nav class="footer-links">
+    <a href="/">Home</a><a href="/support.html">Support</a><a href="/terms-of-use.html">Terms of Use</a><a href="/privacy-policy.html">Privacy Policy</a><a href="/acceptable-use-policy.html">Acceptable Use Policy</a><a href="/copyright.html">Copyright</a>
+  </nav>
+  <div style="opacity:.7;margin-top:.5rem">© 2024 quali.chat. All rights reserved.</div>
+</footer>
+</body></html>

--- a/index.html
+++ b/index.html
@@ -90,14 +90,16 @@
     </section>
   </main>
 
-  <footer class="site-footer">
-    <nav>
-      <a href="./about.html">About</a>
-      <a href="./demo.html">Demo</a>
-      <a href="./terms.html">Terms</a>
-      <a href="./privacy.html">Privacy</a>
+  <footer class="site-footer" style="margin-top:6rem;padding:2.5rem 1rem;border-top:1px solid rgba(255,255,255,.12);display:flex;flex-wrap:wrap;gap:1rem;align-items:center;justify-content:center;font-size:0.95rem;">
+    <nav class="footer-links" style="display:flex;flex-wrap:wrap;gap:1.25rem;text-transform:uppercase;letter-spacing:.02em;">
+      <a href="/" style="opacity:.9;text-decoration:none">Home</a>
+      <a href="/support.html" style="opacity:.9;text-decoration:none">Support</a>
+      <a href="/terms-of-use.html" style="opacity:.9;text-decoration:none">Terms of Use</a>
+      <a href="/privacy-policy.html" style="opacity:.9;text-decoration:none">Privacy Policy</a>
+      <a href="/acceptable-use-policy.html" style="opacity:.9;text-decoration:none">Acceptable Use Policy</a>
+      <a href="/copyright.html" style="opacity:.9;text-decoration:none">Copyright</a>
     </nav>
-    <small>© <span id="year"></span> quali.chat</small>
+    <div style="flex-basis:100%;text-align:center;opacity:.7;margin-top:.75rem;">© 2024 quali.chat. All rights reserved.</div>
   </footer>
 
   <script src="./app.js" defer></script>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,15 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>Privacy Policy – Quali.chat</title><link rel="stylesheet" href="/styles.css"/><style>body{min-height:100svh;display:flex;flex-direction:column}.wrap{max-width:880px;margin:0 auto;padding:2rem}.card{backdrop-filter:saturate(140%) blur(8px);background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.12);border-radius:16px;padding:1.25rem}h1{font-size:2rem;margin:1rem 0 1.25rem}footer{margin-top:auto}</style></head><body>
+<main class="wrap">
+  <h1>Privacy Policy</h1>
+  <div class="card">
+    <p><strong>Content pending.</strong> To include the full Privacy Policy here, paste your owned/authorized text. For now, visit the original page:</p>
+    <p><a href="https://quali.chat/privacy-policy/">https://quali.chat/privacy-policy/</a></p>
+  </div>
+</main>
+<footer class="site-footer" style="margin-top:3rem;padding:2.5rem 1rem;border-top:1px solid rgba(255,255,255,.12);text-align:center">
+  <nav class="footer-links">
+    <a href="/">Home</a><a href="/support.html">Support</a><a href="/terms-of-use.html">Terms of Use</a><a href="/privacy-policy.html">Privacy Policy</a><a href="/acceptable-use-policy.html">Acceptable Use Policy</a><a href="/copyright.html">Copyright</a>
+  </nav>
+  <div style="opacity:.7;margin-top:.5rem">© 2024 quali.chat. All rights reserved.</div>
+</footer>
+</body></html>

--- a/support.html
+++ b/support.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Support – Quali.chat</title>
+  <link rel="stylesheet" href="/styles.css" />
+  <style>
+    body{min-height:100svh;display:flex;flex-direction:column}
+    .wrap{max-width:880px;margin:0 auto;padding:2rem}
+    h1{font-size:2rem;margin:1rem 0 1.25rem}
+    .card{backdrop-filter:saturate(140%) blur(8px);background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.12);border-radius:16px;padding:1.25rem}
+    .note{opacity:.8;font-size:.95rem}
+    footer{margin-top:auto}
+    .footer-links a{text-transform:uppercase;letter-spacing:.02em;margin:0 .6rem}
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <h1>Support</h1>
+    <div class="card">
+      <p class="note">This page is a placeholder in your GitHub Pages site. For official support, use the original channel:</p>
+      <p><a href="mailto:support@quali.chat">support@quali.chat</a></p>
+    </div>
+  </main>
+  <footer class="site-footer" style="margin-top:3rem;padding:2.5rem 1rem;border-top:1px solid rgba(255,255,255,.12);text-align:center">
+    <nav class="footer-links">
+      <a href="/">Home</a><a href="/support.html">Support</a><a href="/terms-of-use.html">Terms of Use</a><a href="/privacy-policy.html">Privacy Policy</a><a href="/acceptable-use-policy.html">Acceptable Use Policy</a><a href="/copyright.html">Copyright</a>
+    </nav>
+    <div style="opacity:.7;margin-top:.5rem">© 2024 quali.chat. All rights reserved.</div>
+  </footer>
+</body>
+</html>

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -1,0 +1,15 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>Terms of Use – Quali.chat</title><link rel="stylesheet" href="/styles.css"/><style>body{min-height:100svh;display:flex;flex-direction:column}.wrap{max-width:880px;margin:0 auto;padding:2rem}.card{backdrop-filter:saturate(140%) blur(8px);background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.12);border-radius:16px;padding:1.25rem}h1{font-size:2rem;margin:1rem 0 1.25rem}footer{margin-top:auto}</style></head><body>
+<main class="wrap">
+  <h1>Terms of Use</h1>
+  <div class="card">
+    <p><strong>Content pending.</strong> To include the full Terms here, paste your owned/authorized text. For now, visit the original page:</p>
+    <p><a href="https://quali.chat/terms-of-use/">https://quali.chat/terms-of-use/</a></p>
+  </div>
+</main>
+<footer class="site-footer" style="margin-top:3rem;padding:2.5rem 1rem;border-top:1px solid rgba(255,255,255,.12);text-align:center">
+  <nav class="footer-links">
+    <a href="/">Home</a><a href="/support.html">Support</a><a href="/terms-of-use.html">Terms of Use</a><a href="/privacy-policy.html">Privacy Policy</a><a href="/acceptable-use-policy.html">Acceptable Use Policy</a><a href="/copyright.html">Copyright</a>
+  </nav>
+  <div style="opacity:.7;margin-top:.5rem">© 2024 quali.chat. All rights reserved.</div>
+</footer>
+</body></html>


### PR DESCRIPTION
## Summary
- update the home page footer to match quali.chat navigation structure and styling
- add support and legal policy placeholder pages that link to the canonical quali.chat resources

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68c878239f40832ba1eb279ec586c81e