### PR TITLE
Standardize footer and hide legal links in header

### DIFF
--- a/acceptable-use-policy.html
+++ b/acceptable-use-policy.html
@@ -6,10 +6,6 @@
     <p><a href="https://quali.chat/acceptable-use-policy/">https://quali.chat/acceptable-use-policy/</a></p>
   </div>
 </main>
-<footer class="site-footer" style="margin-top:3rem;padding:2.5rem 1rem;border-top:1px solid rgba(255,255,255,.12);text-align:center">
-  <nav class="footer-links">
-    <a href="/">Home</a><a href="/support.html">Support</a><a href="/terms-of-use.html">Terms of Use</a><a href="/privacy-policy.html">Privacy Policy</a><a href="/acceptable-use-policy.html">Acceptable Use Policy</a><a href="/copyright.html">Copyright</a>
-  </nav>
-  <div style="opacity:.7;margin-top:.5rem">© 2024 quali.chat. All rights reserved.</div>
-</footer>
+<div id="site-footer"></div>
+<script src="/js/footer.js" defer></script>
 </body></html>

--- a/copyright.html
+++ b/copyright.html
@@ -6,10 +6,6 @@
     <p><a href="https://quali.chat/copyright/">https://quali.chat/copyright/</a></p>
   </div>
 </main>
-<footer class="site-footer" style="margin-top:3rem;padding:2.5rem 1rem;border-top:1px solid rgba(255,255,255,.12);text-align:center">
-  <nav class="footer-links">
-    <a href="/">Home</a><a href="/support.html">Support</a><a href="/terms-of-use.html">Terms of Use</a><a href="/privacy-policy.html">Privacy Policy</a><a href="/acceptable-use-policy.html">Acceptable Use Policy</a><a href="/copyright.html">Copyright</a>
-  </nav>
-  <div style="opacity:.7;margin-top:.5rem">© 2024 quali.chat. All rights reserved.</div>
-</footer>
+<div id="site-footer"></div>
+<script src="/js/footer.js" defer></script>
 </body></html>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>quali.chat — Home</title>
-  <link rel="stylesheet" href="./styles.css" />
+  <link rel="stylesheet" href="/styles.css" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 </head>
 <body>
@@ -90,18 +90,8 @@
     </section>
   </main>
 
-  <footer class="site-footer" style="margin-top:6rem;padding:2.5rem 1rem;border-top:1px solid rgba(255,255,255,.12);display:flex;flex-wrap:wrap;gap:1rem;align-items:center;justify-content:center;font-size:0.95rem;">
-    <nav class="footer-links" style="display:flex;flex-wrap:wrap;gap:1.25rem;text-transform:uppercase;letter-spacing:.02em;">
-      <a href="/" style="opacity:.9;text-decoration:none">Home</a>
-      <a href="/support.html" style="opacity:.9;text-decoration:none">Support</a>
-      <a href="/terms-of-use.html" style="opacity:.9;text-decoration:none">Terms of Use</a>
-      <a href="/privacy-policy.html" style="opacity:.9;text-decoration:none">Privacy Policy</a>
-      <a href="/acceptable-use-policy.html" style="opacity:.9;text-decoration:none">Acceptable Use Policy</a>
-      <a href="/copyright.html" style="opacity:.9;text-decoration:none">Copyright</a>
-    </nav>
-    <div style="flex-basis:100%;text-align:center;opacity:.7;margin-top:.75rem;">© 2024 quali.chat. All rights reserved.</div>
-  </footer>
-
   <script src="./app.js" defer></script>
+  <div id="site-footer"></div>
+  <script src="/js/footer.js" defer></script>
 </body>
 </html>

--- a/js/footer.js
+++ b/js/footer.js
@@ -1,0 +1,12 @@
+(async () => {
+  try {
+    const slot = document.getElementById('site-footer');
+    if (!slot) return;
+    const res = await fetch('/shared/footer.html', { cache: 'no-store' });
+    if (!res.ok) return;
+    const html = await res.text();
+    // Replace placeholder node with footer HTML
+    slot.insertAdjacentHTML('afterend', html);
+    slot.remove();
+  } catch (_) {}
+})();

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -6,10 +6,6 @@
     <p><a href="https://quali.chat/privacy-policy/">https://quali.chat/privacy-policy/</a></p>
   </div>
 </main>
-<footer class="site-footer" style="margin-top:3rem;padding:2.5rem 1rem;border-top:1px solid rgba(255,255,255,.12);text-align:center">
-  <nav class="footer-links">
-    <a href="/">Home</a><a href="/support.html">Support</a><a href="/terms-of-use.html">Terms of Use</a><a href="/privacy-policy.html">Privacy Policy</a><a href="/acceptable-use-policy.html">Acceptable Use Policy</a><a href="/copyright.html">Copyright</a>
-  </nav>
-  <div style="opacity:.7;margin-top:.5rem">© 2024 quali.chat. All rights reserved.</div>
-</footer>
+<div id="site-footer"></div>
+<script src="/js/footer.js" defer></script>
 </body></html>

--- a/shared/footer.html
+++ b/shared/footer.html
@@ -1,0 +1,13 @@
+<footer class="site-footer">
+  <nav class="footer-links">
+    <a href="/">Home</a>
+    <a href="/support.html">Support</a>
+    <a href="/terms-of-use.html">Terms of Use</a>
+    <a href="/privacy-policy.html">Privacy Policy</a>
+    <a href="/acceptable-use-policy.html">Acceptable Use Policy</a>
+    <a href="/copyright.html">Copyright</a>
+  </nav>
+  <div style="flex-basis:100%;text-align:center;opacity:.7;margin-top:.75rem">
+    © 2024 quali.chat. All rights reserved.
+  </div>
+</footer>

--- a/styles.css
+++ b/styles.css
@@ -107,3 +107,23 @@ a{color:inherit;text-decoration:none}
 /* demo page placeholder */
 .demo-embed{padding:24px; border-radius:16px; margin-top:16px}
 .embed-placeholder{opacity:.7; text-align:center; padding:40px 10px; border:1px dashed var(--glass-b); border-radius:12px}
+/* Hide Terms & Privacy from any header/top nav */
+header nav a[href*="terms"],
+header nav a[href*="privacy"],
+.top-nav a[href*="terms"],
+.top-nav a[href*="privacy"] { display: none !important; }
+
+/* Footer base styling (shared) */
+.site-footer {
+  margin-top: 6rem;
+  padding: 2.5rem 1rem;
+  border-top: 1px solid rgba(255,255,255,.12);
+  display: flex; flex-wrap: wrap; gap: 1rem;
+  align-items: center; justify-content: center;
+  font-size: 0.95rem;
+}
+.site-footer .footer-links {
+  display:flex; flex-wrap:wrap; gap:1.25rem;
+  text-transform: uppercase; letter-spacing:.02em;
+}
+.site-footer .footer-links a { opacity:.9; text-decoration:none; }

--- a/support.html
+++ b/support.html
@@ -23,11 +23,7 @@
       <p><a href="mailto:support@quali.chat">support@quali.chat</a></p>
     </div>
   </main>
-  <footer class="site-footer" style="margin-top:3rem;padding:2.5rem 1rem;border-top:1px solid rgba(255,255,255,.12);text-align:center">
-    <nav class="footer-links">
-      <a href="/">Home</a><a href="/support.html">Support</a><a href="/terms-of-use.html">Terms of Use</a><a href="/privacy-policy.html">Privacy Policy</a><a href="/acceptable-use-policy.html">Acceptable Use Policy</a><a href="/copyright.html">Copyright</a>
-    </nav>
-    <div style="opacity:.7;margin-top:.5rem">© 2024 quali.chat. All rights reserved.</div>
-  </footer>
+  <div id="site-footer"></div>
+  <script src="/js/footer.js" defer></script>
 </body>
 </html>

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -6,10 +6,6 @@
     <p><a href="https://quali.chat/terms-of-use/">https://quali.chat/terms-of-use/</a></p>
   </div>
 </main>
-<footer class="site-footer" style="margin-top:3rem;padding:2.5rem 1rem;border-top:1px solid rgba(255,255,255,.12);text-align:center">
-  <nav class="footer-links">
-    <a href="/">Home</a><a href="/support.html">Support</a><a href="/terms-of-use.html">Terms of Use</a><a href="/privacy-policy.html">Privacy Policy</a><a href="/acceptable-use-policy.html">Acceptable Use Policy</a><a href="/copyright.html">Copyright</a>
-  </nav>
-  <div style="opacity:.7;margin-top:.5rem">© 2024 quali.chat. All rights reserved.</div>
-</footer>
+<div id="site-footer"></div>
+<script src="/js/footer.js" defer></script>
 </body></html>


### PR DESCRIPTION
## Summary
- append site-wide CSS to hide legal links in the header and define shared footer styling
- add reusable footer include and loader script, then hook pages into the new placeholder
- switch each page to the shared footer to keep styling consistent

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68c8dd448a88832b90fa002ace27a582