### PR TITLE
Unify footer: clone homepage footer site-wide

### DIFF
--- a/about.html
+++ b/about.html
@@ -41,5 +41,6 @@
     <small>© <span id="year"></span> quali.chat</small>
   </footer>
   <script src="./app.js" defer></script>
+  <script src="/assets/js/footer-sync.js" defer></script>
 </body>
 </html>

--- a/acceptable-use-policy.html
+++ b/acceptable-use-policy.html
@@ -12,4 +12,5 @@
   </nav>
   <div style="opacity:.7;margin-top:.5rem">© 2024 quali.chat. All rights reserved.</div>
 </footer>
+  <script src="/assets/js/footer-sync.js" defer></script>
 </body></html>

--- a/assets/js/footer-sync.js
+++ b/assets/js/footer-sync.js
@@ -1,0 +1,59 @@
+/* Footer Sync: make every page use the EXACT same footer as the homepage.
+   - On non-home pages, fetch the homepage, extract <footer>, and replace/append.
+   - If a previous injected footer (.ql-footer) exists, remove it first.
+   - Tries both "/" and the project base (first path segment) for GitHub Pages.
+*/
+(function () {
+  var path = window.location.pathname;
+  var isHome = /\/(?:index\.html)?$/.test(path); // e.g., "/", "/repo/", "/index.html", "/repo/index.html"
+  if (isHome) return;
+
+  function candidatesFromPath() {
+    var urls = ['/', '/index.html'];
+    var parts = path.split('/').filter(Boolean);
+    if (parts.length) {
+      var base = '/' + parts[0] + '/';
+      urls.push(base, base + 'index.html');
+    }
+    return Array.from(new Set(urls));
+  }
+
+  function fetchHomeFooter(urls) {
+    // Try candidates in order until one yields a <footer>
+    return urls.reduce((chain, url) => {
+      return chain.catch(() =>
+        fetch(url, { cache: 'no-store' }).then(r => {
+          if (!r.ok) throw new Error('Fetch failed: ' + url + ' (' + r.status + ')');
+          return r.text();
+        }).then(html => {
+          var doc = new DOMParser().parseFromString(html, 'text/html');
+          var footer = doc.querySelector('footer');
+          if (!footer) throw new Error('No <footer> on ' + url);
+          return footer.outerHTML;
+        })
+      );
+    }, Promise.reject());
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var urls = candidatesFromPath();
+    fetchHomeFooter(urls).then(function (footerHTML) {
+      // Remove previously injected generic footer if present
+      var oldInjected = document.querySelector('.ql-footer');
+      if (oldInjected) oldInjected.remove();
+
+      var existing = document.querySelector('footer');
+      var wrap = document.createElement('div');
+      wrap.innerHTML = footerHTML;
+      var cloned = wrap.firstElementChild;
+
+      if (existing) {
+        existing.replaceWith(cloned);
+      } else {
+        document.body.appendChild(cloned);
+      }
+    }).catch(function (err) {
+      console.error('Footer sync failed:', err);
+    });
+  });
+})();

--- a/copyright.html
+++ b/copyright.html
@@ -12,4 +12,5 @@
   </nav>
   <div style="opacity:.7;margin-top:.5rem">© 2024 quali.chat. All rights reserved.</div>
 </footer>
+  <script src="/assets/js/footer-sync.js" defer></script>
 </body></html>

--- a/demo.html
+++ b/demo.html
@@ -36,5 +36,6 @@
     <small>© <span id="year"></span> quali.chat</small>
   </footer>
   <script src="./app.js" defer></script>
+  <script src="/assets/js/footer-sync.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -103,5 +103,6 @@
   </footer>
 
   <script src="./app.js" defer></script>
+  <script src="/assets/js/footer-sync.js" defer></script>
 </body>
 </html>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -12,4 +12,5 @@
   </nav>
   <div style="opacity:.7;margin-top:.5rem">© 2024 quali.chat. All rights reserved.</div>
 </footer>
+  <script src="/assets/js/footer-sync.js" defer></script>
 </body></html>

--- a/privacy.html
+++ b/privacy.html
@@ -33,5 +33,6 @@
     <small>© <span id="year"></span> quali.chat</small>
   </footer>
   <script src="./app.js" defer></script>
+  <script src="/assets/js/footer-sync.js" defer></script>
 </body>
 </html>

--- a/support.html
+++ b/support.html
@@ -29,5 +29,6 @@
     </nav>
     <div style="opacity:.7;margin-top:.5rem">© 2024 quali.chat. All rights reserved.</div>
   </footer>
+  <script src="/assets/js/footer-sync.js" defer></script>
 </body>
 </html>

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -12,4 +12,5 @@
   </nav>
   <div style="opacity:.7;margin-top:.5rem">© 2024 quali.chat. All rights reserved.</div>
 </footer>
+  <script src="/assets/js/footer-sync.js" defer></script>
 </body></html>

--- a/terms.html
+++ b/terms.html
@@ -33,5 +33,6 @@
     <small>© <span id="year"></span> quali.chat</small>
   </footer>
   <script src="./app.js" defer></script>
+  <script src="/assets/js/footer-sync.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Replaces any existing/injected footers with an exact clone of the homepage footer on every page for a consistent menu and layout.

------
https://chatgpt.com/codex/tasks/task_e_68c9319a4758832b929e302ecf925cfd