### PR TITLE
Nav cleanup: keep About & Demo + Connect button

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,16 +6,15 @@
   <title>About – quali.chat</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head>
 <body>
   <header class="site-header glass">
     <a class="brand" href="./">quali.chat</a>
-    <nav class="site-nav">
-      <a href="./index.html">Home</a>
-      <a class="active" href="./about.html">About</a>
-      <a href="./demo.html">Demo</a>
-      <a href="./terms.html">Terms</a>
-      <a href="./privacy.html">Privacy</a>
+    <nav class="site-nav nav-list">
+      <a href="#about">About</a>
+      <a href="#demo">Demo</a>
+      <a class="nav-connect" href="/login">Connect</a>
     </nav>
   </header>
 

--- a/acceptable-use-policy.html
+++ b/acceptable-use-policy.html
@@ -1,5 +1,15 @@
 <!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>Acceptable Use Policy – Quali.chat</title><link rel="stylesheet" href="/styles.css"/><style>body{min-height:100svh;display:flex;flex-direction:column}.wrap{max-width:880px;margin:0 auto;padding:2rem}.card{backdrop-filter:saturate(140%) blur(8px);background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.12);border-radius:16px;padding:1.25rem}h1{font-size:2rem;margin:1rem 0 1.25rem}footer{margin-top:auto}</style>  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head><body>
+<header class="site-header glass">
+  <a class="brand" href="./">quali.chat</a>
+  <nav class="site-nav nav-list">
+    <a href="#about">About</a>
+    <a href="#demo">Demo</a>
+    <a class="nav-connect" href="/login">Connect</a>
+  </nav>
+</header>
+
 <main class="wrap">
   <h1>Acceptable Use Policy</h1>
   <div class="card">

--- a/assets/css/nav.css
+++ b/assets/css/nav.css
@@ -1,0 +1,10 @@
+/* Minimal, namespaced nav tweaks */
+.nav-connect {
+  display:inline-flex; align-items:center; gap:.5rem;
+  padding:.55rem .9rem; border-radius:999px;
+  border:1px solid rgba(0,0,0,.14); background:#111; color:#fff;
+  text-decoration:none; font-weight:600; line-height:1;
+}
+.nav-connect:hover { filter:brightness(1.07); }
+.nav-list { display:flex; gap:16px; align-items:center; }
+@media (max-width: 800px){ .nav-connect{padding:.55rem .9rem;} .nav-list{gap:12px;} }

--- a/copyright.html
+++ b/copyright.html
@@ -1,5 +1,15 @@
 <!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>Copyright – Quali.chat</title><link rel="stylesheet" href="/styles.css"/><style>body{min-height:100svh;display:flex;flex-direction:column}.wrap{max-width:880px;margin:0 auto;padding:2rem}.card{backdrop-filter:saturate(140%) blur(8px);background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.12);border-radius:16px;padding:1.25rem}h1{font-size:2rem;margin:1rem 0 1.25rem}footer{margin-top:auto}</style>  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head><body>
+<header class="site-header glass">
+  <a class="brand" href="./">quali.chat</a>
+  <nav class="site-nav nav-list">
+    <a href="#about">About</a>
+    <a href="#demo">Demo</a>
+    <a class="nav-connect" href="/login">Connect</a>
+  </nav>
+</header>
+
 <main class="wrap">
   <h1>Copyright</h1>
   <div class="card">

--- a/demo.html
+++ b/demo.html
@@ -6,16 +6,15 @@
   <title>Demo – quali.chat</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head>
 <body>
   <header class="site-header glass">
     <a class="brand" href="./">quali.chat</a>
-    <nav class="site-nav">
-      <a href="./index.html">Home</a>
-      <a href="./about.html">About</a>
-      <a class="active" href="./demo.html">Demo</a>
-      <a href="./terms.html">Terms</a>
-      <a href="./privacy.html">Privacy</a>
+    <nav class="site-nav nav-list">
+      <a href="#about">About</a>
+      <a href="#demo">Demo</a>
+      <a class="nav-connect" href="/login">Connect</a>
     </nav>
   </header>
 

--- a/index.html
+++ b/index.html
@@ -6,16 +6,15 @@
   <title>quali.chat — Home</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head>
 <body>
   <header class="site-header glass">
     <a class="brand" href="./">quali.chat</a>
-    <nav class="site-nav">
-      <a class="active" href="./index.html">Home</a>
-      <a href="./about.html">About</a>
-      <a href="./demo.html">Demo</a>
-      <a href="./terms.html">Terms</a>
-      <a href="./privacy.html">Privacy</a>
+    <nav class="site-nav nav-list">
+      <a href="#about">About</a>
+      <a href="#demo">Demo</a>
+      <a class="nav-connect" href="/login">Connect</a>
     </nav>
   </header>
 

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,5 +1,15 @@
 <!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>Privacy Policy – Quali.chat</title><link rel="stylesheet" href="/styles.css"/><style>body{min-height:100svh;display:flex;flex-direction:column}.wrap{max-width:880px;margin:0 auto;padding:2rem}.card{backdrop-filter:saturate(140%) blur(8px);background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.12);border-radius:16px;padding:1.25rem}h1{font-size:2rem;margin:1rem 0 1.25rem}footer{margin-top:auto}</style>  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head><body>
+<header class="site-header glass">
+  <a class="brand" href="./">quali.chat</a>
+  <nav class="site-nav nav-list">
+    <a href="#about">About</a>
+    <a href="#demo">Demo</a>
+    <a class="nav-connect" href="/login">Connect</a>
+  </nav>
+</header>
+
 <main class="wrap">
   <h1>Privacy Policy</h1>
   <div class="card">

--- a/privacy.html
+++ b/privacy.html
@@ -6,16 +6,15 @@
   <title>Privacy Policy – quali.chat</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head>
 <body>
   <header class="site-header glass">
     <a class="brand" href="./">quali.chat</a>
-    <nav class="site-nav">
-      <a href="./index.html">Home</a>
-      <a href="./about.html">About</a>
-      <a href="./demo.html">Demo</a>
-      <a href="./terms.html">Terms</a>
-      <a class="active" href="./privacy.html">Privacy</a>
+    <nav class="site-nav nav-list">
+      <a href="#about">About</a>
+      <a href="#demo">Demo</a>
+      <a class="nav-connect" href="/login">Connect</a>
     </nav>
   </header>
 

--- a/support.html
+++ b/support.html
@@ -15,8 +15,18 @@
     .footer-links a{text-transform:uppercase;letter-spacing:.02em;margin:0 .6rem}
   </style>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head>
 <body>
+  <header class="site-header glass">
+    <a class="brand" href="./">quali.chat</a>
+    <nav class="site-nav nav-list">
+      <a href="#about">About</a>
+      <a href="#demo">Demo</a>
+      <a class="nav-connect" href="/login">Connect</a>
+    </nav>
+  </header>
+
   <main class="wrap">
     <h1>Support</h1>
     <div class="card">

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -1,5 +1,15 @@
 <!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>Terms of Use – Quali.chat</title><link rel="stylesheet" href="/styles.css"/><style>body{min-height:100svh;display:flex;flex-direction:column}.wrap{max-width:880px;margin:0 auto;padding:2rem}.card{backdrop-filter:saturate(140%) blur(8px);background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.12);border-radius:16px;padding:1.25rem}h1{font-size:2rem;margin:1rem 0 1.25rem}footer{margin-top:auto}</style>  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head><body>
+<header class="site-header glass">
+  <a class="brand" href="./">quali.chat</a>
+  <nav class="site-nav nav-list">
+    <a href="#about">About</a>
+    <a href="#demo">Demo</a>
+    <a class="nav-connect" href="/login">Connect</a>
+  </nav>
+</header>
+
 <main class="wrap">
   <h1>Terms of Use</h1>
   <div class="card">

--- a/terms.html
+++ b/terms.html
@@ -6,16 +6,15 @@
   <title>Terms of Use – quali.chat</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head>
 <body>
   <header class="site-header glass">
     <a class="brand" href="./">quali.chat</a>
-    <nav class="site-nav">
-      <a href="./index.html">Home</a>
-      <a href="./about.html">About</a>
-      <a href="./demo.html">Demo</a>
-      <a class="active" href="./terms.html">Terms</a>
-      <a href="./privacy.html">Privacy</a>
+    <nav class="site-nav nav-list">
+      <a href="#about">About</a>
+      <a href="#demo">Demo</a>
+      <a class="nav-connect" href="/login">Connect</a>
     </nav>
   </header>
 


### PR DESCRIPTION
## Summary
- add a dedicated nav stylesheet to style the new Connect call-to-action
- trim each header navigation down to About, Demo, and the Connect button while loading the new CSS
- add the shared header/nav markup to support and policy placeholder pages for consistency

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c957dd2630832b9addf5a1958eb001