### PR TITLE
Nav cleanup: keep About & Demo + Connect button

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,16 +6,15 @@
   <title>About – quali.chat</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head>
 <body>
   <header class="site-header glass">
     <a class="brand" href="./">quali.chat</a>
-    <nav class="site-nav">
-      <a href="./index.html">Home</a>
-      <a class="active" href="./about.html">About</a>
-      <a href="./demo.html">Demo</a>
-      <a href="./terms.html">Terms</a>
-      <a href="./privacy.html">Privacy</a>
+    <nav class="site-nav nav-list">
+      <a href="#about">About</a>
+      <a href="#demo">Demo</a>
+      <a class="nav-connect" href="/login">Connect</a>
     </nav>
   </header>
 

--- a/acceptable-use-policy.html
+++ b/acceptable-use-policy.html
@@ -1,5 +1,15 @@
 <!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>Acceptable Use Policy – Quali.chat</title><link rel="stylesheet" href="/styles.css"/><style>body{min-height:100svh;display:flex;flex-direction:column}.wrap{max-width:880px;margin:0 auto;padding:2rem}.card{backdrop-filter:saturate(140%) blur(8px);background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.12);border-radius:16px;padding:1.25rem}h1{font-size:2rem;margin:1rem 0 1.25rem}footer{margin-top:auto}</style>  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head><body>
+<header class="site-header glass">
+  <a class="brand" href="./">quali.chat</a>
+  <nav class="site-nav nav-list">
+    <a href="#about">About</a>
+    <a href="#demo">Demo</a>
+    <a class="nav-connect" href="/login">Connect</a>
+  </nav>
+</header>
+
 <main class="wrap">
   <h1>Acceptable Use Policy</h1>
   <div class="card">

--- a/assets/css/nav.css
+++ b/assets/css/nav.css
@@ -1,0 +1,10 @@
+/* Minimal, namespaced nav tweaks */
+.nav-connect {
+  display:inline-flex; align-items:center; gap:.5rem;
+  padding:.55rem .9rem; border-radius:999px;
+  border:1px solid rgba(0,0,0,.14); background:#111; color:#fff;
+  text-decoration:none; font-weight:600; line-height:1;
+}
+.nav-connect:hover { filter:brightness(1.07); }
+.nav-list { display:flex; gap:16px; align-items:center; }
+@media (max-width: 800px){ .nav-connect{padding:.55rem .9rem;} .nav-list{gap:12px;} }

--- a/copyright.html
+++ b/copyright.html
@@ -1,5 +1,15 @@
 <!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>Copyright – Quali.chat</title><link rel="stylesheet" href="/styles.css"/><style>body{min-height:100svh;display:flex;flex-direction:column}.wrap{max-width:880px;margin:0 auto;padding:2rem}.card{backdrop-filter:saturate(140%) blur(8px);background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.12);border-radius:16px;padding:1.25rem}h1{font-size:2rem;margin:1rem 0 1.25rem}footer{margin-top:auto}</style>  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head><body>
+<header class="site-header glass">
+  <a class="brand" href="./">quali.chat</a>
+  <nav class="site-nav nav-list">
+    <a href="#about">About</a>
+    <a href="#demo">Demo</a>
+    <a class="nav-connect" href="/login">Connect</a>
+  </nav>
+</header>
+
 <main class="wrap">
   <h1>Copyright</h1>
   <div class="card">

--- a/demo.html
+++ b/demo.html
@@ -6,16 +6,15 @@
   <title>Demo – quali.chat</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head>
 <body>
   <header class="site-header glass">
     <a class="brand" href="./">quali.chat</a>
-    <nav class="site-nav">
-      <a href="./index.html">Home</a>
-      <a href="./about.html">About</a>
-      <a class="active" href="./demo.html">Demo</a>
-      <a href="./terms.html">Terms</a>
-      <a href="./privacy.html">Privacy</a>
+    <nav class="site-nav nav-list">
+      <a href="#about">About</a>
+      <a href="#demo">Demo</a>
+      <a class="nav-connect" href="/login">Connect</a>
     </nav>
   </header>
 

--- a/index.html
+++ b/index.html
@@ -6,16 +6,15 @@
   <title>quali.chat — Home</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head>
 <body>
   <header class="site-header glass">
     <a class="brand" href="./">quali.chat</a>
-    <nav class="site-nav">
-      <a class="active" href="./index.html">Home</a>
-      <a href="./about.html">About</a>
-      <a href="./demo.html">Demo</a>
-      <a href="./terms.html">Terms</a>
-      <a href="./privacy.html">Privacy</a>
+    <nav class="site-nav nav-list">
+      <a href="#about">About</a>
+      <a href="#demo">Demo</a>
+      <a class="nav-connect" href="/login">Connect</a>
     </nav>
   </header>
 
@@ -32,46 +31,49 @@
         </div>
       </div>
 
-      <!-- iPhone mockup (single overlay) -->
-      <figure class="iphone tilt">
-        <div class="iphone-frame">
-          <div class="iphone-notch"></div>
-          <div class="iphone-screen">
-            <div class="chat-list">
-              <div class="chat chat--active">
-                <div class="avatar">Q</div>
-                <div class="meta">
-                  <div class="title">quali.chat</div>
-                  <div class="sub">All Chats</div>
+      <!-- iPhone mockup with subtle orbit animation -->
+      <div class="phone-wrap">
+        <div class="phone-orbit"><span></span><span></span><span></span></div>
+        <figure class="iphone tilt">
+          <div class="iphone-frame">
+            <div class="iphone-notch"></div>
+            <div class="iphone-screen">
+              <div class="chat-list">
+                <div class="chat chat--active">
+                  <div class="avatar">Q</div>
+                  <div class="meta">
+                    <div class="title">quali.chat</div>
+                    <div class="sub">All Chats</div>
+                  </div>
+                  <div class="time">now</div>
                 </div>
-                <div class="time">now</div>
-              </div>
-              <div class="chat">
-                <div class="avatar">Ξ</div>
-                <div class="meta">
-                  <div class="title">Ethereum</div>
-                  <div class="sub">Mainnet updates</div>
+                <div class="chat">
+                  <div class="avatar">Ξ</div>
+                  <div class="meta">
+                    <div class="title">Ethereum</div>
+                    <div class="sub">Mainnet updates</div>
+                  </div>
+                  <div class="time">3m</div>
                 </div>
-                <div class="time">3m</div>
-              </div>
-              <div class="chat">
-                <div class="avatar">R</div>
-                <div class="meta">
-                  <div class="title">Research</div>
-                  <div class="sub">Token gating notes</div>
+                <div class="chat">
+                  <div class="avatar">R</div>
+                  <div class="meta">
+                    <div class="title">Research</div>
+                    <div class="sub">Token gating notes</div>
+                  </div>
+                  <div class="time">9m</div>
                 </div>
-                <div class="time">9m</div>
               </div>
-            </div>
 
-            <!-- SINGLE toast (glassy), optional image shows if uploaded later -->
-            <div class="token-toast glass">
-              <img class="toast-img" src="images/autoaccess.png" alt="Auto access" onerror="this.style.display='none'">
-              <div class="toast-text">YOU WERE ADDED TO YOUR TOKEN CHATS</div>
+              <!-- SINGLE toast (glassy), optional image shows if uploaded later -->
+              <div class="token-toast glass">
+                <img class="toast-img" src="images/autoaccess.png" alt="Auto access" onerror="this.style.display='none'">
+                <div class="toast-text">YOU WERE ADDED TO YOUR TOKEN CHATS</div>
+              </div>
             </div>
           </div>
-        </div>
-      </figure>
+        </figure>
+      </div>
     </section>
 
     <section class="features">

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,5 +1,15 @@
 <!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>Privacy Policy – Quali.chat</title><link rel="stylesheet" href="/styles.css"/><style>body{min-height:100svh;display:flex;flex-direction:column}.wrap{max-width:880px;margin:0 auto;padding:2rem}.card{backdrop-filter:saturate(140%) blur(8px);background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.12);border-radius:16px;padding:1.25rem}h1{font-size:2rem;margin:1rem 0 1.25rem}footer{margin-top:auto}</style>  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head><body>
+<header class="site-header glass">
+  <a class="brand" href="./">quali.chat</a>
+  <nav class="site-nav nav-list">
+    <a href="#about">About</a>
+    <a href="#demo">Demo</a>
+    <a class="nav-connect" href="/login">Connect</a>
+  </nav>
+</header>
+
 <main class="wrap">
   <h1>Privacy Policy</h1>
   <div class="card">

--- a/privacy.html
+++ b/privacy.html
@@ -6,16 +6,15 @@
   <title>Privacy Policy – quali.chat</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head>
 <body>
   <header class="site-header glass">
     <a class="brand" href="./">quali.chat</a>
-    <nav class="site-nav">
-      <a href="./index.html">Home</a>
-      <a href="./about.html">About</a>
-      <a href="./demo.html">Demo</a>
-      <a href="./terms.html">Terms</a>
-      <a class="active" href="./privacy.html">Privacy</a>
+    <nav class="site-nav nav-list">
+      <a href="#about">About</a>
+      <a href="#demo">Demo</a>
+      <a class="nav-connect" href="/login">Connect</a>
     </nav>
   </header>
 

--- a/styles.css
+++ b/styles.css
@@ -37,6 +37,7 @@ a{color:inherit;text-decoration:none}
 
 .wrap{max-width:var(--max); margin:40px auto; padding:0 20px}
 .hero{display:grid; gap:40px; align-items:center; grid-template-columns: 1.05fr .95fr}
+.hero h1{font-size:4rem; line-height:1.05; margin:0 0 .6em}
 @media (max-width:980px){ .hero{grid-template-columns:1fr} .iphone{justify-self:center} }
 .lead{color:var(--muted); max-width:52ch}
 .cta{display:flex; gap:12px; margin-top:16px}
@@ -67,7 +68,7 @@ a{color:inherit;text-decoration:none}
 }
 /* right-side thickness */
 .iphone-frame::after{
-  content:""; position:absolute; top:-1px; right:-14px; bottom:-1px; width:14px; border-radius:0 28px 28px 0;
+  content:""; position:absolute; top:-1px; right:-18px; bottom:-1px; width:18px; border-radius:0 28px 28px 0;
   background:linear-gradient(90deg, rgba(0,0,0,.6), rgba(255,255,255,.15)); filter:blur(.3px)
 }
 /* thin bezel highlight */
@@ -75,7 +76,20 @@ a{color:inherit;text-decoration:none}
   content:""; position:absolute; inset:0; border-radius:32px; pointer-events:none;
   box-shadow: inset 0 0 0 2px rgba(255,255,255,.06), inset 0 0 20px rgba(0,0,0,.35);
 }
-.tilt{transform: perspective(1400px) rotateY(-9deg) rotateX(2deg); transform-origin:center right}
+.tilt{transform:perspective(1400px) rotateY(-16deg) rotateX(5deg); transform-origin:center right}
+.phone-wrap{position:relative}
+.phone-orbit{
+  position:absolute; top:50%; left:50%; width:400px; height:400px; margin:-200px 0 0 -200px;
+  border-radius:50%; z-index:-1; animation:orbit 20s linear infinite;
+}
+.phone-orbit span{
+  position:absolute; top:50%; left:50%; width:6px; height:6px; margin:-3px;
+  border-radius:50%; background:rgba(255,255,255,.2);
+}
+.phone-orbit span:nth-child(1){transform:translateX(200px)}
+.phone-orbit span:nth-child(2){transform:rotate(120deg) translateX(200px)}
+.phone-orbit span:nth-child(3){transform:rotate(240deg) translateX(200px)}
+@keyframes orbit{from{transform:rotate(0deg);}to{transform:rotate(360deg);}}
 .iphone-notch{
   position:absolute; top:8px; left:50%; transform:translateX(-50%);
   width:152px; height:26px; background:#0a0d13; border-radius:16px;

--- a/support.html
+++ b/support.html
@@ -15,8 +15,18 @@
     .footer-links a{text-transform:uppercase;letter-spacing:.02em;margin:0 .6rem}
   </style>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head>
 <body>
+  <header class="site-header glass">
+    <a class="brand" href="./">quali.chat</a>
+    <nav class="site-nav nav-list">
+      <a href="#about">About</a>
+      <a href="#demo">Demo</a>
+      <a class="nav-connect" href="/login">Connect</a>
+    </nav>
+  </header>
+
   <main class="wrap">
     <h1>Support</h1>
     <div class="card">

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -1,5 +1,15 @@
 <!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>Terms of Use – Quali.chat</title><link rel="stylesheet" href="/styles.css"/><style>body{min-height:100svh;display:flex;flex-direction:column}.wrap{max-width:880px;margin:0 auto;padding:2rem}.card{backdrop-filter:saturate(140%) blur(8px);background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.12);border-radius:16px;padding:1.25rem}h1{font-size:2rem;margin:1rem 0 1.25rem}footer{margin-top:auto}</style>  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head><body>
+<header class="site-header glass">
+  <a class="brand" href="./">quali.chat</a>
+  <nav class="site-nav nav-list">
+    <a href="#about">About</a>
+    <a href="#demo">Demo</a>
+    <a class="nav-connect" href="/login">Connect</a>
+  </nav>
+</header>
+
 <main class="wrap">
   <h1>Terms of Use</h1>
   <div class="card">

--- a/terms.html
+++ b/terms.html
@@ -6,16 +6,15 @@
   <title>Terms of Use – quali.chat</title>
   <link rel="stylesheet" href="./styles.css" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="/assets/css/nav.css">
 </head>
 <body>
   <header class="site-header glass">
     <a class="brand" href="./">quali.chat</a>
-    <nav class="site-nav">
-      <a href="./index.html">Home</a>
-      <a href="./about.html">About</a>
-      <a href="./demo.html">Demo</a>
-      <a class="active" href="./terms.html">Terms</a>
-      <a href="./privacy.html">Privacy</a>
+    <nav class="site-nav nav-list">
+      <a href="#about">About</a>
+      <a href="#demo">Demo</a>
+      <a class="nav-connect" href="/login">Connect</a>
     </nav>
   </header>
 


### PR DESCRIPTION
## Summary
- add a dedicated nav stylesheet to style the new Connect call-to-action
- trim each header navigation down to About, Demo, and the Connect button while loading the new CSS
- add the shared header/nav markup to support and policy placeholder pages for consistency
- double the hero headline size so the Quali.chat value proposition stands out
- animate subtle orbiting dots behind the phone mockup and deepen its 3D tilt

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c957dd2630832b9addf5a1958eb001