### PR TITLE
Update header navigation links to use page URLs

### DIFF
--- a/about.html
+++ b/about.html
@@ -12,8 +12,8 @@
   <header class="site-header glass">
     <a class="brand" href="./">quali.chat</a>
     <nav class="site-nav nav-list">
-      <a href="#about">About</a>
-      <a href="#demo">Demo</a>
+      <a href="/about.html">About</a>
+      <a href="/demo.html">Demo</a>
       <a class="nav-connect" href="/login">Connect</a>
     </nav>
   </header>

--- a/acceptable-use-policy.html
+++ b/acceptable-use-policy.html
@@ -4,8 +4,8 @@
 <header class="site-header glass">
   <a class="brand" href="./">quali.chat</a>
   <nav class="site-nav nav-list">
-    <a href="#about">About</a>
-    <a href="#demo">Demo</a>
+    <a href="/about.html">About</a>
+    <a href="/demo.html">Demo</a>
     <a class="nav-connect" href="/login">Connect</a>
   </nav>
 </header>

--- a/copyright.html
+++ b/copyright.html
@@ -4,8 +4,8 @@
 <header class="site-header glass">
   <a class="brand" href="./">quali.chat</a>
   <nav class="site-nav nav-list">
-    <a href="#about">About</a>
-    <a href="#demo">Demo</a>
+    <a href="/about.html">About</a>
+    <a href="/demo.html">Demo</a>
     <a class="nav-connect" href="/login">Connect</a>
   </nav>
 </header>

--- a/demo.html
+++ b/demo.html
@@ -12,8 +12,8 @@
   <header class="site-header glass">
     <a class="brand" href="./">quali.chat</a>
     <nav class="site-nav nav-list">
-      <a href="#about">About</a>
-      <a href="#demo">Demo</a>
+      <a href="/about.html">About</a>
+      <a href="/demo.html">Demo</a>
       <a class="nav-connect" href="/login">Connect</a>
     </nav>
   </header>

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
   <header class="site-header glass">
     <a class="brand" href="./">quali.chat</a>
     <nav class="site-nav nav-list">
-      <a href="#about">About</a>
-      <a href="#demo">Demo</a>
+      <a href="/about.html">About</a>
+      <a href="/demo.html">Demo</a>
       <a class="nav-connect" href="/login">Connect</a>
     </nav>
   </header>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -4,8 +4,8 @@
 <header class="site-header glass">
   <a class="brand" href="./">quali.chat</a>
   <nav class="site-nav nav-list">
-    <a href="#about">About</a>
-    <a href="#demo">Demo</a>
+    <a href="/about.html">About</a>
+    <a href="/demo.html">Demo</a>
     <a class="nav-connect" href="/login">Connect</a>
   </nav>
 </header>

--- a/privacy.html
+++ b/privacy.html
@@ -12,8 +12,8 @@
   <header class="site-header glass">
     <a class="brand" href="./">quali.chat</a>
     <nav class="site-nav nav-list">
-      <a href="#about">About</a>
-      <a href="#demo">Demo</a>
+      <a href="/about.html">About</a>
+      <a href="/demo.html">Demo</a>
       <a class="nav-connect" href="/login">Connect</a>
     </nav>
   </header>

--- a/support.html
+++ b/support.html
@@ -21,8 +21,8 @@
   <header class="site-header glass">
     <a class="brand" href="./">quali.chat</a>
     <nav class="site-nav nav-list">
-      <a href="#about">About</a>
-      <a href="#demo">Demo</a>
+      <a href="/about.html">About</a>
+      <a href="/demo.html">Demo</a>
       <a class="nav-connect" href="/login">Connect</a>
     </nav>
   </header>

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -4,8 +4,8 @@
 <header class="site-header glass">
   <a class="brand" href="./">quali.chat</a>
   <nav class="site-nav nav-list">
-    <a href="#about">About</a>
-    <a href="#demo">Demo</a>
+    <a href="/about.html">About</a>
+    <a href="/demo.html">Demo</a>
     <a class="nav-connect" href="/login">Connect</a>
   </nav>
 </header>

--- a/terms.html
+++ b/terms.html
@@ -12,8 +12,8 @@
   <header class="site-header glass">
     <a class="brand" href="./">quali.chat</a>
     <nav class="site-nav nav-list">
-      <a href="#about">About</a>
-      <a href="#demo">Demo</a>
+      <a href="/about.html">About</a>
+      <a href="/demo.html">Demo</a>
       <a class="nav-connect" href="/login">Connect</a>
     </nav>
   </header>


### PR DESCRIPTION
## Summary
- replace the header navigation "About" and "Demo" anchors across all HTML pages to point to their standalone pages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c982449cb0832ba4e803fb1e017216